### PR TITLE
California OSM/Tobler Notebook

### DIFF
--- a/geopyspark/notebooks/cali-osm-tobler.ipynb
+++ b/geopyspark/notebooks/cali-osm-tobler.ipynb
@@ -1,0 +1,703 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating the Friction Surface for California"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import geopyspark as gps\n",
+    "import numpy as np\n",
+    "import pyproj\n",
+    "import fiona\n",
+    "\n",
+    "from functools import partial\n",
+    "from shapely.geometry import shape, MultiPoint, MultiLineString\n",
+    "from shapely.ops import transform\n",
+    "from pyspark import SparkContext, StorageLevel\n",
+    "from pyspark.sql import SparkSession\n",
+    "from geonotebook.wrappers import VectorData, TMSRasterData\n",
+    "\n",
+    "conf = gps.geopyspark_conf(appName=\"gps-osm-ingest\", master='local[*]')\n",
+    "conf.set('spark.executor.extraJavaOptions', '-XX:+UseCompressedOops')\n",
+    "conf.set('spark.driver.extraJavaOptions', '-XX:+UseCompressedOops')\n",
+    "conf.set('spark.jars.packages', 'org.apache.hadoop:hadoop-aws:2.7.0')\n",
+    "conf.set(\"spark.hadoop.yarn.timeline-service.enabled\", False)\n",
+    "conf.set('spark.ui.enabled', True)\n",
+    "conf.set('spark.default.parallelism', 256)\n",
+    "conf.set('spark.driver.memory', '9500M')\n",
+    "conf.set('spark.executor.memory', '9500M')\n",
+    "conf.set('spark.executor.cores', 4)\n",
+    "conf.set('spark.yarn.executor.memoryOverhead', '1500M')\n",
+    "conf.set('spark.master.memory', '9500M')\n",
+    "conf.set('spark.yarn.driver.memoryOverhead', '1500M')\n",
+    "conf.set('spark.dynamicAllocation.enabled', True)\n",
+    "conf.set('spark.shuffle.service.enabled', True)\n",
+    "\n",
+    "sc = SparkContext(conf=conf)\n",
+    "\n",
+    "hadoopConf = sc._jsc.hadoopConfiguration()\n",
+    "hadoopConf.set(\"fs.s3.impl\", \"org.apache.hadoop.fs.s3native.NativeS3FileSystem\")\n",
+    "hadoopConf.set(\"fs.s3.awsAccessKeyId\", 'access_key_id')\n",
+    "hadoopConf.set(\"fs.s3.awsSecretAccessKey\", 'secret_access_key')\n",
+    "\n",
+    "pysc = gps.get_spark_context()\n",
+    "session = SparkSession.builder.config(conf=pysc.getConf()).enableHiveSupport().getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M.set_center(-120.212158203125, 37.86618078529668, 6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculating the Friction Layer From OSM and SRTM Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# This cell contains the logic that assigns each section of road a\n",
+    "# speed based on the type of road that section is.\n",
+    "\n",
+    "default_speeds = {\n",
+    "'motorway':100,\n",
+    "'trunk':70,\n",
+    "'primary':65,\n",
+    "'secondary':60,\n",
+    "'tertiary':50,\n",
+    "'unclassified':30,\n",
+    "'residential':30,\n",
+    "'service':20,\n",
+    "'motorway_link':70,\n",
+    "'trunk_link':65,\n",
+    "'primary_link':60,\n",
+    "'secondary_link':50,\n",
+    "'tertiary_link':40,\n",
+    "'living_street':10,\n",
+    "'pedestrian':6,\n",
+    "'track':20,\n",
+    "'road':35}\n",
+    "\n",
+    "country_speeds = {\n",
+    "'at:urban':50,\n",
+    "'at:rural':100,\n",
+    "'at:trunk':100,\n",
+    "'at:motorway':130,\n",
+    "'ch:urban':50,\n",
+    "'ch:rural':80,\n",
+    "'ch:trunk':100,\n",
+    "'ch:motorway':120,\n",
+    "'cz:urban':50,\n",
+    "'cz:rural':90,\n",
+    "'cz:trunk':130,\n",
+    "'cz:motorway':130,\n",
+    "'dk:urban':50,\n",
+    "'dk:rural':80,\n",
+    "'dk:motorway':130,\n",
+    "'de:living_street':7,\n",
+    "'de:urban':50,\n",
+    "'de:walk':7,\n",
+    "'de:rural':100,\n",
+    "'fi:urban':50,\n",
+    "'fi:rural':80,\n",
+    "'fi:trunk':100,\n",
+    "'fi:motorway':120,\n",
+    "'fr:urban':50,\n",
+    "'fr:rural':90,\n",
+    "'fr:trunk':110,\n",
+    "'fr:motorway':130,\n",
+    "'hu:urban':50,\n",
+    "'hu:rural':90,\n",
+    "'hu:trunk':110,\n",
+    "'hu:motorway':130,\n",
+    "'it:urban':50,\n",
+    "'it:rural':90,\n",
+    "'it:trunk':110,\n",
+    "'it:motorway':130,\n",
+    "'jp:national':60,\n",
+    "'jp:motorway':100,\n",
+    "'ro:urban':50,\n",
+    "'ro:rural':90,\n",
+    "'ro:trunk':100,\n",
+    "'ro:motorway':130,\n",
+    "'ru:living_street':20,\n",
+    "'ru:rural':90,\n",
+    "'ru:urban':60,\n",
+    "'ru:motorway':110,\n",
+    "'sk:urban':50,\n",
+    "'sk:rural':90,\n",
+    "'sk:trunk':130,\n",
+    "'sk:motorway':130,\n",
+    "'si:urban':50,\n",
+    "'si:rural':90,\n",
+    "'si:trunk':110,\n",
+    "'si:motorway':130,\n",
+    "'se:urban':50,\n",
+    "'se:rural':70,\n",
+    "'se:trunk':90,\n",
+    "'se:motorway':110,\n",
+    "'gb:nsl_single':96.54,\n",
+    "'gb:nsl_dual':112.63,\n",
+    "'gb:motorway':112.63,\n",
+    "'ua:urban':60,\n",
+    "'ua:rural':90,\n",
+    "'ua:trunk':110,\n",
+    "'ua:motorway':130,\n",
+    "'living_street':6}\n",
+    "\n",
+    "words = ['maxspeed', 'ambiguous', 'signals', \n",
+    "         'none', 'walk', 'variable', \n",
+    "         'national', 'fixme', 'unposted', 'implicit']\n",
+    "\n",
+    "def is_number(s):\n",
+    "    try:\n",
+    "        float(s)\n",
+    "        return True\n",
+    "    except ValueError:\n",
+    "        return False\n",
+    "\n",
+    "def default_speed(highway):\n",
+    "    if not highway in default_speeds:\n",
+    "        return default_speeds['road']\n",
+    "    else:\n",
+    "        return default_speeds[highway]\n",
+    "\n",
+    "def get_maxspeed(speed, units, highway):\n",
+    "    speeds = speed.split(';|,-')\n",
+    "    maxspeed = 0\n",
+    "    for sp in speeds:\n",
+    "        sp = sp.replace(units, '')\n",
+    "        if (is_number(sp)):\n",
+    "            if units == 'mph':\n",
+    "                sp = 1.609 * float(sp) \n",
+    "            elif units == 'knots':\n",
+    "                sp = 1.852 * float(knots)\n",
+    "            else:\n",
+    "                sp = float(sp)\n",
+    "                \n",
+    "            if sp > maxspeed:\n",
+    "                maxspeed = sp\n",
+    "    if maxspeed > 0:\n",
+    "        speed = maxspeed\n",
+    "    else:\n",
+    "        speed = default_speed(highway)\n",
+    "\n",
+    "    return speed\n",
+    "\n",
+    "def get_highway_cellvalue(osm_feature):   \n",
+    "    highway = osm_feature.properties.tags['highway']\n",
+    "    speed = osm_feature.properties.tags.get('maxspeed', '')\n",
+    "                                \n",
+    "    speed = speed.lower().strip()\n",
+    "        \n",
+    "    # if we don't have a speed, give it a default\n",
+    "    if len(speed) == 0:\n",
+    "        speed = default_speed(highway)\n",
+    "    elif not is_number(speed):\n",
+    "        if 'kph' in speed:\n",
+    "            speed = get_maxspeed(speed, 'kph', highway)\n",
+    "        elif 'km/h' in speed:\n",
+    "            speed = get_maxspeed(speed, 'km/h', highway)\n",
+    "        elif 'kmh' in speed:\n",
+    "            speed = get_maxspeed(speed, 'kmh', highway)\n",
+    "        elif 'mph' in speed:\n",
+    "            speed = get_maxspeed(speed, 'mph', highway)\n",
+    "        elif 'knots' in speed:\n",
+    "            speed = get_maxspeed(speed, 'knots', highway)\n",
+    "        elif speed in country_speeds:\n",
+    "            speed = country_speeds[speed]\n",
+    "        elif speed in words:\n",
+    "            speed = default_speed(highway)\n",
+    "        else:\n",
+    "            speed = get_maxspeed(speed, '', highway)            \n",
+    "    if float(speed) <= 0.0:\n",
+    "        speed = default_speed(highway)\n",
+    "\n",
+    "    speed = float(speed)\n",
+    "    return gps.CellValue(speed, speed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading and Formatting the OSM Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Reading in the ORC file as a Spark DataFrame\n",
+    "\n",
+    "file_uri = \"s3://geotrellis-test/dg-srtm/california.orc\"\n",
+    "osm_dataframe = session.read.orc(file_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get all of the lines that are contained within the DataFrame\n",
+    "\n",
+    "osm = gps.vector_pipe.osm_reader.from_dataframe(osm_dataframe)\n",
+    "lines = osm.get_line_features_rdd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Only highways are of interest\n",
+    "highways = lines.filter(lambda feature: 'highway' in feature.properties.tags)\n",
+    "\n",
+    "# Shows the OSM tags of the first element in the highways RDD\n",
+    "highways.take(1)[0].properties.tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Encode highway speeds as feature properties for rasterization\n",
+    "highway_features = highways.map(\n",
+    "    lambda feature:    \n",
+    "        gps.Feature(feature.geometry, get_highway_cellvalue(feature)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# The first Feature in the RDD that contains the geometry and CellValue\n",
+    "highway_features.take(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "highway_raster = gps.geotrellis.rasterize_features(\n",
+    "    features = highway_features,\n",
+    "    crs = 4326,\n",
+    "    zoom = 10,\n",
+    "    cell_type=gps.CellType.INT8RAW,\n",
+    "    num_partitions = 256,\n",
+    "    partitioner = gps.Partitioner.SPATIAL_PARTITIONER\n",
+    ").persist(StorageLevel.MEMORY_AND_DISK)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying the Rasterized Highways"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "color_map = gps.ColorMap.from_colors(\n",
+    "    breaks = np.arange(8, 100, 4), \n",
+    "    color_list = gps.get_colors_from_matplotlib('magma'))\n",
+    "\n",
+    "osm_wm = highway_raster.tile_to_layout(gps.GlobalLayout(tile_size=256), target_crs=3857)\n",
+    "\n",
+    "layer = gps.TMS.build(osm_wm.convert_data_type(gps.CellType.INT8, 0).pyramid(), color_map)\n",
+    "M.add_layer(TMSRasterData(layer), name=\"OSM-highways\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "M.remove_layer(M.layers[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading the SRTM Data and Calculating the Friction Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cali_extent = gps.Extent(xmin=-126.27685546874999, ymin=32.26855544621476, \n",
+    "                         xmax=-113.97216796875, ymax=42.4234565179383)\n",
+    "\n",
+    "# Read SRTM for the same extent as rasterized OSM features\n",
+    "srtm = gps.query(\n",
+    "    uri=\"s3://geotrellis-test/dg-srtm\",\n",
+    "    layer_name=\"srtm-wsg84-gps\", \n",
+    "    layer_zoom = 0,\n",
+    "    query_geom = cali_extent,\n",
+    "    query_proj = 4326,\n",
+    "    num_partitions = 256\n",
+    ")\n",
+    "\n",
+    "# Tile SRTM layer to same layout as rasterized OSM features\n",
+    "tiled_srtm = srtm.tile_to_layout(highway_raster.layer_metadata).convert_data_type(gps.CellType.INT16, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Calculate the ZFactors based on the SRTM Layer's projection and units\n",
+    "zfactor = gps.geotrellis.zfactor_lat_lng_calculator('Meters')\n",
+    "\n",
+    "# Perform the Tobler operation on the resulting slope layer\n",
+    "tobler_raster = tiled_srtm.slope(zfactor).tobler()\n",
+    "\n",
+    "# Create the friction layer by performing a local max on the Tobler layer\n",
+    "# using the Highway layer\n",
+    "friction = tobler_raster.local_max(highway_raster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "highway_raster.unpersist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "reprojected = friction.tile_to_layout(\n",
+    "    target_crs = 3857,\n",
+    "    layout = gps.GlobalLayout(tile_size=256),\n",
+    "    resample_method = gps.ResampleMethod.MAX\n",
+    ").convert_data_type(gps.CellType.FLOAT32, -2147483648.0).persist(StorageLevel.MEMORY_AND_DISK_SER)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pyramid = reprojected.pyramid().persist(StorageLevel.MEMORY_AND_DISK_SER)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying the Friction Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Building the color map from the histogram of the pyramid\n",
+    "hist_color_map = gps.ColorMap.build(pyramid.get_histogram(), 'magma')\n",
+    "hist_layer = gps.TMS.build(pyramid, hist_color_map)\n",
+    "\n",
+    "M.add_layer(TMSRasterData(hist_layer), name=\"ToblerOSM-from-hist\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M.remove_layer(M.layers[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculating Cost Distance Using the Tobler Layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading and Formatting the Population Centers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Downloads the Manx population centers from S3\n",
+    "\n",
+    "!curl -o /tmp/california_pop_centers.geojson https://s3.amazonaws.com/geotrellis-test/dg-srtm/california_pop_centers.geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with fiona.open(\"/tmp/california_pop_centers.geojson\") as source:\n",
+    "    pop_centers = [shape(f['geometry']) for f in source]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# The population centers in question\n",
+    "MultiPoint(pop_centers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Reproject the population centers so that they are in WebMercator\n",
+    "project = partial(\n",
+    "    pyproj.transform,\n",
+    "    pyproj.Proj(init='epsg:4326'),\n",
+    "    pyproj.Proj(init='epsg:3857'))\n",
+    "\n",
+    "reprojected_pop_centers = [transform(project, geom) for geom in pop_centers]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculating Cost Distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cost_distance = gps.cost_distance(3.6 / reprojected,\n",
+    "                                  reprojected_pop_centers[:6],\n",
+    "                                  15000000.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cd_pyramid = cost_distance.pyramid().persist(StorageLevel.MEMORY_AND_DISK_SER)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying Cost Distance and the Population Centers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "cd_color_map = gps.ColorMap.build(cd_pyramid.get_histogram(), 'viridis')\n",
+    "cd_layer = gps.TMS.build(cd_pyramid, cd_color_map)\n",
+    "\n",
+    "M.add_layer(TMSRasterData(cd_layer), name=\"ToblerOSM-cost-distance\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "M.add_layer(VectorData(\"/tmp/manx_pop_centers.geojson\"),\n",
+    "            name=\"Manx Population Centers\",\n",
+    "            colors=[0xff0000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = 0\n",
+    "while x < len(M.layers):\n",
+    "    M.remove_layer(M.layers[x])\n",
+    "    x += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Saving and Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Write the firction layer pyramid to the catalog\n",
+    "for layer in pyramid.levels.values():\n",
+    "    gps.write(\"s3://geotrellis-test/dg-osm-test-cali\", \"gps-osm-ingest\", layer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "reprojected.unpersist()\n",
+    "pyramid.unpersist()\n",
+    "cd_pyramid.unpersist()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Geonotebook (Python 3)",
+   "language": "python",
+   "name": "geonotebook3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a Jupyter Notebook that calculates Tobler walking speeds using roads from OSM and elevation from SRTM. In addition to calculating the walking speed for California, cost distance analysis was performed between population centers with the OSM/Tobler layer as the friction layer.