### PR TITLE
ZFactor Calculator

### DIFF
--- a/src/main/scala/ingest/Slope.scala
+++ b/src/main/scala/ingest/Slope.scala
@@ -4,7 +4,6 @@ import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal.{Square, Slope => TileSlope}
 import geotrellis.spark._
 import geotrellis.spark.buffer._
-import org.apache.commons.math.analysis.interpolation._
 
 object Slope {
   /** Calculate slope on elevation raster in meters in WSG84/LatLng raster
@@ -12,19 +11,16 @@ object Slope {
     * Each tile will havei its own z-factor for slope calculation based on its latitude.
     */
   def fromWGS84(elevation: TileLayerRDD[SpatialKey]): TileLayerRDD[SpatialKey] = {
-    val lattitude = Array[Double](0, 10, 20, 30, 40, 50, 60, 70, 80)
-    val zfactors = Array[Double](0.00000898, 0.00000912, 0.00000956, 0.00001036, 0.00001171, 0.00001395, 0.00001792, 0.00002619, 0.00005156)
+    val zfactorCalculator = (lat: Double) => 1 / (11320 * math.cos(math.toRadians(lat)))
     val cellSize = elevation.metadata.cellSize
     val mt = elevation.metadata.mapTransform
 
     elevation.withContext{ rdd =>
       rdd.bufferTiles(bufferSize = 1).mapPartitions[(SpatialKey, Tile)](
         { iter =>
-          val interp = new LinearInterpolator()
-          val spline = interp.interpolate(lattitude, zfactors)
           iter.map { case (key, BufferedTile(tile, bounds)) =>
             val tileCenter = mt.keyToExtent(key).center
-            val zfactor = spline.value(tileCenter.y)
+            val zfactor = zfactorCalculator(tileCenter.y)
             key -> TileSlope(tile, Square(1), Some(bounds), cellSize, zfactor).interpretAs(FloatConstantNoDataCellType)
           }
         },


### PR DESCRIPTION
This PR changes how the `ZFactor` for each `Tile` will calculated. Rather than interpolating it, it will be calculated directly.

**Note:** The added `ZFactor` function assumes the elevation of a layer is in meters.