### PR TITLE
NPS RI Friction Notebook Improvements

### DIFF
--- a/geopyspark/notebooks/NPS-RI-friction.ipynb
+++ b/geopyspark/notebooks/NPS-RI-friction.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating the Friction Surface for Rhode Island"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -27,8 +34,8 @@
     "\n",
     "hadoopConf = sc._jsc.hadoopConfiguration()\n",
     "hadoopConf.set(\"fs.s3.impl\", \"org.apache.hadoop.fs.s3native.NativeS3FileSystem\")\n",
-    "hadoopConf.set(\"fs.s3.awsAccessKeyId\", '***')\n",
-    "hadoopConf.set(\"fs.s3.awsSecretAccessKey\", '***')\n",
+    "hadoopConf.set(\"fs.s3.awsAccessKeyId\", 'your_access_key')\n",
+    "hadoopConf.set(\"fs.s3.awsSecretAccessKey\", 'your_secret_key')\n",
     "\n",
     "pysc = gps.get_spark_context()\n",
     "session = SparkSession.builder.config(conf=pysc.getConf()).enableHiveSupport().getOrCreate()"
@@ -37,7 +44,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.set_center(-71.88333333333334, 41.15, 8)"
@@ -58,13 +67,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading and  the Road And Path Features"
+    "## Calculating the Friction Surface From OSM, NLCD, NHD, and NED Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading and Formatting the OSM Data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -225,7 +242,18 @@
     "# Filter out the highways into roads and paths\n",
     "\n",
     "roads = highways.filter(lambda feature: feature.properties.tags['highway'] not in path_tags)\n",
-    "paths = highways.filter(lambda feature: feature.properties.tags['highway'] in path_tags).map(lambda feature: feature.geometry)"
+    "paths = highways.filter(lambda feature: feature.properties.tags['highway'] in path_tags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path_features = paths.map(lambda feature: gps.Feature(feature.geometry, gps.CellValue(3.74, 3.74)))"
    ]
   },
   {
@@ -243,7 +271,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "road_raster = gps.geotrellis.rasterize_features(\n",
@@ -256,16 +286,45 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": [
-    "## Displaying the Rasterized Roads"
+    "path_raster = gps.geotrellis.rasterize_features(\n",
+    "    features = path_features,\n",
+    "    crs = 4326,\n",
+    "    zoom = 10,\n",
+    "    cell_type=gps.CellType.INT8RAW,\n",
+    "    partition_strategy = gps.SpatialPartitionStrategy(32)\n",
+    ").convert_data_type(gps.CellType.FLOAT32, -2147483648.0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tiled_path_raster = path_raster.tile_to_layout(road_raster.layer_metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying the Rasterized Roads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -283,7 +342,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -293,40 +354,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading and Formatting NLCD Data"
+    "### Reading and Formatting the NLCD Data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "nlcd_pmts_map = {\n",
-    "    11: 0.0,\n",
-    "    12: 0.15,\n",
-    "    21: 0.9,\n",
-    "    22: 0.9,\n",
-    "    23: 0.9,\n",
-    "    24: 0.95,\n",
-    "    31: 0.1,\n",
-    "    41: 0.7,\n",
-    "    42: 0.65,\n",
-    "    43: 0.75,\n",
-    "    51: 0.75,\n",
-    "    52: 0.75,\n",
-    "    71: 0.8,\n",
-    "    81: 0.8,\n",
-    "    82: 0.8,\n",
-    "    90: 0.2,\n",
-    "    95: 0.25\n",
+    "    11.0: 0.0,\n",
+    "    12.0: 0.15,\n",
+    "    21.0: 0.9,\n",
+    "    22.0: 0.9,\n",
+    "    23.0: 0.9,\n",
+    "    24.0: 0.95,\n",
+    "    31.0: 0.1,\n",
+    "    41.0: 0.7,\n",
+    "    42.0: 0.65,\n",
+    "    43.0: 0.75,\n",
+    "    51.0: 0.75,\n",
+    "    52.0: 0.75,\n",
+    "    71.0: 0.8,\n",
+    "    81.0: 0.8,\n",
+    "    82.0: 0.8,\n",
+    "    90.0: 0.2,\n",
+    "    95.0: 0.25\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Reading NLCD Data\n",
@@ -341,11 +406,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "nlcd_pmts = masked_nlcd.reclassify(value_map=nlcd_pmts_map,\n",
-    "                                   data_type=int,\n",
+    "                                   data_type=float,\n",
     "                                   classification_strategy=gps.ClassificationStrategy.EXACT\n",
     "                                  ).convert_data_type(gps.CellType.FLOAT32, 0.0)"
    ]
@@ -354,18 +421,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Displaying the NLCD Data"
+    "### Displaying the NLCD Data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "nlcd_tms = nlcd_pmts.tile_to_layout(gps.GlobalLayout(tile_size=256), target_crs=3857)\n",
     "\n",
-    "color_map = gps.ColorMap.build(nlcd_tms.get_class_histogram(), 'magma')\n",
+    "color_map = gps.ColorMap.build(nlcd_tms.get_histogram(), 'magma')\n",
     "\n",
     "layer = gps.TMS.build(nlcd_tms.pyramid(), color_map)\n",
     "M.add_layer(TMSRasterData(layer), name=\"NLCD-Data\")"
@@ -375,6 +444,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -386,7 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading and Formatting NHD Data"
+    "### Reading and Formatting the NHD Data"
    ]
   },
   {
@@ -398,6 +468,7 @@
    "outputs": [],
    "source": [
     "nhd_pmts_map = {\n",
+    "    0: 0.0,\n",
     "    1: 0.7,\n",
     "    2: 0.6,\n",
     "    3: 0.5,\n",
@@ -438,7 +509,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "nhd_raster = gps.geotrellis.rasterize_features(\n",
@@ -447,13 +520,15 @@
     "    zoom = 10,\n",
     "    cell_type=gps.CellType.FLOAT32RAW,\n",
     "    partition_strategy = gps.SpatialPartitionStrategy(32)\n",
-    ")#.convert_data_type(gps.CellType.FLOAT32, 0.0)"
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tiled_nhd = nhd_raster.tile_to_layout(road_raster.layer_metadata, partition_strategy=gps.SpatialPartitionStrategy(32))"
@@ -462,7 +537,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "masked_nhd = tiled_nhd.mask(rhode_island_extent.to_polygon, partition_strategy=gps.SpatialPartitionStrategy(32))"
@@ -472,13 +549,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Displaying the Rasterized NHD Features"
+    "### Displaying the Rasterized NHD Features"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "color_map = gps.ColorMap.from_colors(\n",
@@ -497,7 +576,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "collapsed": true,
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -508,7 +588,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading and Formatting NED Data"
+    "### Reading and Formatting the NED Data"
    ]
   },
   {
@@ -526,7 +606,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ned_raw = gps.geotiff.get(gps.LayerType.SPATIAL, ned_files, num_partitions=32, max_tile_size=256)"
@@ -535,24 +617,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tiled_ned = ned_raw.tile_to_layout(road_raster.layer_metadata, partition_strategy=gps.SpatialPartitionStrategy(32))\n",
-    "masked_ned = tiled_ned.mask(rhode_island_extent.to_polygon, partition_strategy=gps.SpatialPartitionStrategy(32)).convert_data_type(gps.CellType.FLOAT32, -2147483648.0)"
+    "masked_ned = tiled_ned.mask(rhode_island_extent.to_polygon, partition_strategy=gps.SpatialPartitionStrategy(32)).convert_data_type(gps.CellType.FLOAT32, 0.0)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Displaying the NED Data"
+    "### Displaying the NED Data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ned_tms = masked_ned.tile_to_layout(gps.GlobalLayout(tile_size=256), target_crs=3857)\n",
@@ -566,7 +652,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -576,7 +665,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Caculating Tobler Walking Speeds"
+    "### Caculating Tobler Walking Speeds"
    ]
   },
   {
@@ -595,53 +684,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
    "source": [
     "tobler_raster = slope_raster.tobler()\n",
-    "adjusted_tobler = tobler_raster + tiled_nhd #((masked_nhd + nlcd_pmts) / 2.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "masked_tobler = tobler_raster.mask(paths, partition_strategy=gps.SpatialPartitionStrategy(32)).convert_data_type(gps.CellType.FLOAT32RAW)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "friction_no_roads = masked_tobler.local_max(adjusted_tobler)\n",
-    "friction_with_roads = adjusted_tobler.local_max(road_raster)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reprojected = friction_with_roads.tile_to_layout(\n",
-    "    target_crs = 3857,\n",
-    "    layout = gps.GlobalLayout(tile_size=256),\n",
-    "    resample_method = gps.ResampleMethod.MAX\n",
-    ").convert_data_type(gps.CellType.FLOAT32, -2147483648.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reprojected.layer_metadata"
+    "adjusted_tobler = (tobler_raster + tiled_nhd + nlcd_pmts) - tiled_path_raster"
    ]
   },
   {
@@ -652,20 +701,47 @@
    },
    "outputs": [],
    "source": [
-    "pyramid = reprojected.pyramid(partition_strategy=gps.SpatialPartitionStrategy(32)).persist(StorageLevel.MEMORY_AND_DISK_SER)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Displaying the Fricition Layer"
+    "friction_with_roads = adjusted_tobler.local_max(road_raster)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "reprojected = friction_with_roads.tile_to_layout(\n",
+    "    target_crs = 3857,\n",
+    "    layout = gps.GlobalLayout(tile_size=256),\n",
+    "    resample_method = gps.ResampleMethod.MAX\n",
+    ").convert_data_type(gps.CellType.FLOAT32, 0.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pyramid = reprojected.pyramid(partition_strategy=gps.SpatialPartitionStrategy(32))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying the Fricition Layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -681,11 +757,41 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "collapsed": true,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Calulating Cost Distance Using the Tobler Layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading and Formatting Rhode Island Points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Downloads the RI points from S3\n",
+    "\n",
+    "!curl -o /tmp/ri-points.geojson https://s3.amazonaws.com/geotrellis-test/xterrain/ri-points.geojson"
    ]
   },
   {
@@ -695,12 +801,110 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "with fiona.open(\"ri-points.geojson\") as source:\n",
+    "    pop_centers = [shape(f['geometry']) for f in source]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "project = partial(\n",
+    "    pyproj.transform,\n",
+    "    pyproj.Proj(init='epsg:4326'),\n",
+    "    pyproj.Proj(init='epsg:3857'))\n",
+    "\n",
+    "reprojected_pop_centers = [transform(project, geom) for geom in pop_centers]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculating Cost Distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "cost_distance = gps.cost_distance(3.74 / reprojected,\n",
+    "                                  reprojected_pop_centers,\n",
+    "                                  100000.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "cd_pyramid = cost_distance.pyramid()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Displaying Cost Distance and the Points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "cd_color_map = gps.ColorMap.build(cd_pyramid.get_histogram(), 'viridis')\n",
+    "cd_layer = gps.TMS.build(cd_pyramid, cd_color_map)\n",
+    "\n",
+    "M.add_layer(TMSRasterData(cd_layer), name=\"ToblerOSM-cost-distance\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "M.add_layer(VectorData(\"ri-points.geojson\"),\n",
+    "            name=\"Manx Population Centers\",\n",
+    "            colors=[0xff0000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = 0\n",
+    "while x < len(M.layers):\n",
+    "    M.remove_layer(M.layers[x])\n",
+    "    x += 1"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark",
+   "display_name": "Geonotebook (Python 3)",
    "language": "python",
    "name": "geonotebook3"
   },
@@ -714,7 +918,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR makes it so that the NPS RI friction notebook will now produce a friction surface using all of the specified factors. In addition, another section has been added that will calculate cost distance using the aforementioned fiction layer. Along with these two sections, the notebook has been reformatted to make it easier to read and follow.